### PR TITLE
Lower cpu usage

### DIFF
--- a/runqueue.py
+++ b/runqueue.py
@@ -1,4 +1,5 @@
 from api.queue import Queue
+import time
 
 
 if __name__ == '__main__':
@@ -7,3 +8,4 @@ if __name__ == '__main__':
     # Run the queue in an endless loop
     while True:
         queue.run()
+        time.sleep(0.01)


### PR DESCRIPTION
Turns out just running `python -c 'while True: pass'` will also use up an entire cpu. Easy fix is throwing a time.sleep in there!

I still think it's kind of overkill to use a database for this purpose, and would like to take a stab at rewriting with https://docs.python.org/3/library/queue.html. Then we would only need to start a single process. If we're still worried about picking up jobs after an error, we could wrap everything in a try/finally block and pickle the queue object so it can easily restart.